### PR TITLE
Correct system property for defining the kms url

### DIFF
--- a/source/tutorials/java/tutorial-magicmirror.rst
+++ b/source/tutorials/java/tutorial-magicmirror.rst
@@ -40,7 +40,7 @@ Firefox).
 
    .. sourcecode:: bash
 
-      mvn compile exec:java -Dkms.ws.url=ws://kms_host:kms_port/kurento
+      mvn compile exec:java -Dkms.url=ws://kms_host:kms_port/kurento
 
 
 Understanding this example


### PR DESCRIPTION
The property for defining the kms url in de text is not the same as the one on the code snippet. I corrected the code snippet to use the correct kms.url property.
