### PR TITLE
Remove duplicate kms_host from ws_uri example

### DIFF
--- a/source/tutorials/node/tutorial-helloworld.rst
+++ b/source/tutorials/node/tutorial-helloworld.rst
@@ -61,7 +61,7 @@ WebRTC capable browser (Chrome, Firefox).
 
    .. sourcecode:: bash
 
-      npm start -- --ws_uri=ws://kms_host:kms_host:kms_port/kurento
+      npm start -- --ws_uri=ws://kms_host:kms_port/kurento
 
    In this case you need to use npm version 2. To update it you can use this command:
 


### PR DESCRIPTION
The example showing how to reference an external Kurento Media Server included a duplicate entry for kms_host.
