### PR TITLE
Docs correction regarding the need for STUN with Kurento installed on cloud/VPS servers

### DIFF
--- a/source/faq.rst
+++ b/source/faq.rst
@@ -13,8 +13,8 @@ How do I...
 ...install Kurento Media Server in an Amazon EC2 instance?
 ----------------------------------------------------------
 
-   If you are installing Kurento in a NAT environment (i.e. in any cloud
-   provider), you'll need to provide a STUN server configuration in
+   If you are installing Kurento in a NAT environment (i.e. behind a
+   router), you'll need to provide a STUN server configuration in
    ``/etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini``. Apart from that,
    you will have to open all UDP ports in your security group, as STUN will use
    any port available from the whole 0-65535 range.

--- a/source/faq.rst
+++ b/source/faq.rst
@@ -13,10 +13,7 @@ How do I...
 ...install Kurento Media Server in an Amazon EC2 instance?
 ----------------------------------------------------------
 
-   If you are installing Kurento in a NAT environment (i.e. behind a
-   router), you'll need to provide a STUN server configuration in
-   ``/etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini``. Apart from that,
-   you will have to open all UDP ports in your security group, as STUN will use
+   You will have to open all UDP ports in your security group, as STUN will use
    any port available from the whole 0-65535 range.
 
    Though for most situations it's enough to configure a STUN server in the KMS


### PR DESCRIPTION
1) VPS/cloud servers with public ips from cloud providers are not behind NAT
2) Thus Kurento will find it's own public ip (host ice candidate) during candidate discovery when it's acting as an endpoint (no need for STUN). 