### PR TITLE
Corrected the typo in kurento_utils_js.rst file

### DIFF
--- a/source/features/kurento_utils_js.rst
+++ b/source/features/kurento_utils_js.rst
@@ -158,7 +158,7 @@ the ICE candidate
 
 Following the previous steps, we have:
 
-* Sent and SDP offer to a remote peer
+* Sent an SDP offer to a remote peer
 
 * Received an SDP answer from the remote peer, and have the ``webRtcPeer``
   process that answer.


### PR DESCRIPTION
There was small typo in documentation. Instead of '**Sent an SDP** offer to a remote peer', it was '**Sent and SDP** offer to a remote peer'